### PR TITLE
Disable dark mode in `p-multiselect`

### DIFF
--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -11,6 +11,9 @@ export default {
     app.use(PrimeVue, {
       theme: {
         preset: Aura,
+        options: {
+          darkModeSelector: "", // Disable dark mode
+        },
       },
     });
     app.component("MultiSelect", MultiSelect);


### PR DESCRIPTION
The multi-select filter on the `Papers/` page changed its style based on dark mode system settings even though dark mode should be disabled for the website.