### PR TITLE
Fix Software documentation links

### DIFF
--- a/.vitepress/theme/Software.vue
+++ b/.vitepress/theme/Software.vue
@@ -42,7 +42,7 @@ export default {
                     <div v-if="project.excerpt" class="max-w-none text-gray-500 mt-2" v-html="project.excerpt">
                     </div>
                     <p class="max-w-none text-gray-700 mt-2 md:mt-4">
-                        Check out the <a :href="project.documentation">documentation</a>
+                        Check out the <a :href="project.documentation" rel="external" target="_blank">documentation</a>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This fixes the links to the documentation for `alignparse`, `neutcurve`, and `polyclonal`.