### PR TITLE
Add dynamic canonical url

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -36,4 +36,17 @@ export default defineConfig({
       },
     ],
   ],
+  // Add canonical link to each page (https://vitepress.dev/reference/site-config#example-adding-a-canonical-url-link)
+  // It's necessary to do this because we need to tell google that we're hosting from jbloomlab.org and not from github.io
+  transformPageData(pageData) {
+    const canonicalUrl = `https://jbloomlab.org/${pageData.relativePath}`
+      .replace(/index\.md$/, "")
+      .replace(/\.md$/, ".html");
+
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push([
+      "link",
+      { rel: "canonical", href: canonicalUrl },
+    ]);
+  },
 });


### PR DESCRIPTION
Google search console was giving us the following warning: `Duplicate without user-selected canonical`. This warning is because we're hosting the website at jbloomlab.github.io and jbloomlab.org and Google sees these as 'duplicate content'.  I fixed this issue by adding a dynamically generated 'canonical' link to the head of each page. This tells Google that the version of the website we care about is located at jbloomlab.org/<page>.