### PR TITLE
fix: member cards consistent styling

### DIFF
--- a/.vitepress/theme/components/TeamMembers.vue
+++ b/.vitepress/theme/components/TeamMembers.vue
@@ -1,6 +1,7 @@
 <script>
 import { computed } from 'vue'
 import TeamMembersItem from './TeamMembersItem.vue'
+
 export default {
     components: {
         TeamMembersItem
@@ -18,13 +19,10 @@ export default {
     }
 }
 </script>
+
 <template>
     <div :class="classes">
-        <div class="max-w-sm grid grid-cols-1 md:grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-6" :class="{
-            'md:max-w-7xl': members.length >= 3,
-            'md:max-w-[14rem]': members.length === 1,
-            'md:max-w-3xl': members.length === 2
-        }">
+        <div class="mx-auto max-w-sm md:max-w-7xl grid grid-cols-1 md:grid-cols-[repeat(auto-fill,minmax(14rem,1fr))] gap-6">
             <div v-for="member in members" :key="member.name" class="item">
                 <TeamMembersItem :member="member" />
             </div>


### PR DESCRIPTION
I was looking at the deployed site and noticed my card was a bit thinner when I decreased the window size. Notice in the screenshot below that my card is just a bit thinner because I hardcoded the width previously. I did a fair bit of UI work years ago and this was bugging me 🙂 

I think overall, how this was set up before, we had different styling settings for sections with >= 3 members, 1 team member, and 2 members. It doesn't really make sense to me, it looks like it's sort of an artifact of the past. I think the styling rules should be applied to all containers the same no matter how many members are there. 

I think this is consistent and cleaner and we won't have to worry about messing with these styling any longer for any sections or team members we add. 

Before this fix (deployed now)

<img width="1014" height="771" alt="image" src="https://github.com/user-attachments/assets/43391f92-0c58-415b-8eea-2dcec9bcacca" />


After this fix (locally):

<img width="1091" height="776" alt="image" src="https://github.com/user-attachments/assets/0d79e055-f96d-4724-afc2-0e04e5cf4071" />


Smoke test LGTM:


<img width="1037" height="487" alt="image" src="https://github.com/user-attachments/assets/093a7313-7e06-4031-a8ea-aed26b21a475" />

